### PR TITLE
[ci] Allow non-atomic action interpreter to be released in conan

### DIFF
--- a/.github/workflows/release_non_atomic_action_interpreter_module.yml
+++ b/.github/workflows/release_non_atomic_action_interpreter_module.yml
@@ -24,6 +24,5 @@ jobs:
           directory: non-atomic-action-interpreter-module
           configure-preset: release-conan
           build-preset: release
-          create-conan-package: false
           conan-username: ${{ secrets.CONAN_USERNAME }}
           conan-api-key: ${{ secrets.CONAN_API_KEY }}


### PR DESCRIPTION
* [ ] Read PR [documentation](https://github.com/ostis-ai/ostis-ps-lib/blob/main/_docs/CONTRIBUTING.md)
* [ ] Update changelog
* [ ] Update documentation

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enable Conan package creation for non-atomic action interpreter module in GitHub Actions workflow.
> 
>   - **Workflow Changes**:
>     - In `.github/workflows/release_non_atomic_action_interpreter_module.yml`, removed `create-conan-package: false` to allow Conan package creation for the non-atomic action interpreter module.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ostis-ai%2Fostis-ps-lib&utm_source=github&utm_medium=referral)<sup> for a84cf184abd0f86a5b2a7115b44bb811edabc7d5. You can [customize](https://app.ellipsis.dev/ostis-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->