### PR TITLE
[feat][non-atomic-module] Bump sc-machine version to 0.10.5

### DIFF
--- a/.github/workflows/release_non_atomic_action_interpreter_module.yml
+++ b/.github/workflows/release_non_atomic_action_interpreter_module.yml
@@ -20,7 +20,7 @@ jobs:
         uses: ostis-ai/release-conan@0.1.0
         with:
           name: non-atomic-action-interpreter-module
-          version: 0.1.0
+          version: 0.1.1
           directory: non-atomic-action-interpreter-module
           configure-preset: release-conan
           build-preset: release

--- a/non-atomic-action-interpreter-module/CMakeLists.txt
+++ b/non-atomic-action-interpreter-module/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.24)
 set(CMAKE_CXX_STANDARD 17)
-project(non-atomic-action-interpreter-module VERSION 0.1.0 LANGUAGES C CXX)
+project(non-atomic-action-interpreter-module VERSION 0.1.1 LANGUAGES C CXX)
 message(STATUS "Current project version: ${CMAKE_PROJECT_VERSION}")
 cmake_policy(SET CMP0048 NEW)
 

--- a/non-atomic-action-interpreter-module/conanfile.py
+++ b/non-atomic-action-interpreter-module/conanfile.py
@@ -10,8 +10,8 @@ class non_atomic_action_interpreter_moduleRecipe(ConanFile):
         return tools.get_env("CONAN_RUN_TESTS", False)
     
     def requirements(self):
-        self.requires("sc-machine/0.10.0")
-        self.requires("ps-common-lib/0.1.0")
+        self.requires("sc-machine/0.10.5", override=True)
+        self.requires("ps-common-lib/0.1.1")
 
     def build_requirements(self):
         self.test_requires("gtest/1.14.0")


### PR DESCRIPTION
* [x] Read PR [documentation](https://github.com/ostis-ai/ostis-ps-lib/blob/main/_docs/CONTRIBUTING.md)
* [ ] Update changelog
* [x] Update documentation

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Bump `non-atomic-action-interpreter-module` version to `0.1.1` and update dependencies in `conanfile.py`.
> 
>   - **Dependencies**:
>     - Update `sc-machine` to version `0.10.5` and `ps-common-lib` to version `0.1.1` in `conanfile.py`.
>   - **Versioning**:
>     - Bump `non-atomic-action-interpreter-module` version to `0.1.1` in `CMakeLists.txt` and `release_non_atomic_action_interpreter_module.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ostis-ai%2Fostis-ps-lib&utm_source=github&utm_medium=referral)<sup> for 04daa5bf485a3b04a3d2040a1eb978007367d210. You can [customize](https://app.ellipsis.dev/ostis-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->